### PR TITLE
Add configdir facility for CLI's

### DIFF
--- a/cli/configdir.go
+++ b/cli/configdir.go
@@ -1,0 +1,136 @@
+// Copyright © 2021 Optable Technologies Inc. All rights reserved.
+// See LICENSE for details.
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type ConfigLoader interface {
+	Unmarshal([]byte) (interface{}, error)
+	Marshal(interface{}) ([]byte, error)
+}
+
+// Simple implementation of a loader marshaling from/into a flat json map
+type JSONMapLoader struct{}
+
+func (l *JSONMapLoader) Unmarshal(b []byte) (interface{}, error) {
+	object := make(map[string]interface{})
+	if err := json.Unmarshal(b, &object); err != nil {
+		return nil, err
+	}
+	return object, nil
+}
+
+func (l *JSONMapLoader) Marshal(obj interface{}) ([]byte, error) {
+	return json.Marshal(obj)
+}
+
+// ConfigDir allows managing a multiple contextual configuration files
+type ConfigDir struct {
+	path   string
+	loader ConfigLoader
+}
+
+// We might want to make that configurable, the idea of having a known suffix is to allow
+// other programs to write files in the config dir without being picked up by the facility.
+// There might be better ways of doing that.
+const configExt = ".conf"
+
+func NewConfigDir(path string, loader ConfigLoader) (*ConfigDir, error) {
+	stat, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+	if !stat.Mode().IsDir() {
+		return nil, fmt.Errorf("%s is not a directory", path)
+	}
+
+	return &ConfigDir{path, loader}, nil
+}
+
+func (c *ConfigDir) LoadPath(path string) (interface{}, error) {
+	bytes, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed loading config at %s: %w", path, err)
+	}
+
+	return c.loader.Unmarshal(bytes)
+}
+
+func (c *ConfigDir) DumpPath(path string, configData interface{}) error {
+	bytes, err := c.loader.Marshal(configData)
+	if err != nil {
+		return fmt.Errorf("failed marshaling config at %s: %w", path, err)
+	}
+
+	return os.WriteFile(path, bytes, 0666)
+}
+
+func (c *ConfigDir) configPath(name string) string {
+	return filepath.Join(c.path, name) + configExt
+}
+
+func (c *ConfigDir) Get(name string) (interface{}, error) {
+	return c.LoadPath(c.configPath(name))
+}
+
+func (c *ConfigDir) Set(name string, configData interface{}) error {
+	return c.DumpPath(c.configPath(name), configData)
+}
+
+func (c *ConfigDir) Use(name string) error {
+	configPath := c.configPath(name)
+	linkPath := filepath.Join(c.path, "current")
+	return os.Symlink(configPath, linkPath)
+}
+
+func configName(path string) string {
+	return filepath.Base(strings.TrimSuffix(path, configExt))
+}
+
+func (c *ConfigDir) List() ([]string, error) {
+	entries, err := os.ReadDir(c.path)
+	if err != nil {
+		return nil, err
+	}
+
+	list := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if filepath.Ext(entry.Name()) != configExt || !entry.Type().IsRegular() {
+			continue
+		}
+
+		list = append(list, configName(entry.Name()))
+	}
+
+	return list, nil
+}
+
+func (c *ConfigDir) Current() (string, interface{}, error) {
+	linkPath := filepath.Join(c.path, "current")
+	info, err := os.Lstat(linkPath)
+	if err != nil {
+		return "", nil, err
+	}
+
+	if info.Mode()&os.ModeSymlink == 0 {
+		return "", nil, errors.New("invalid current link")
+	}
+
+	currentPath, err := os.Readlink(linkPath)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed loading current link: %w", err)
+	}
+
+	config, err := c.LoadPath(currentPath)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed loading current config: %w", err)
+	}
+	return configName(currentPath), config, nil
+}

--- a/cli/configdir.go
+++ b/cli/configdir.go
@@ -7,112 +7,80 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/adrg/xdg"
+	"github.com/alecthomas/kong"
 )
 
-type ConfigLoader interface {
-	Unmarshal([]byte, interface{}) error
-	Marshal(interface{}) ([]byte, error)
-}
-
-// Simple implementation of a loader marshaling from/into a json structure
-type JSONLoader struct{}
-
-func (l *JSONLoader) Unmarshal(b []byte, to interface{}) error {
-	return json.Unmarshal(b, to)
-}
-
-func (l *JSONLoader) Marshal(from interface{}) ([]byte, error) {
-	return json.Marshal(from)
-}
-
-// ConfigDir allows managing a multiple contextual configuration files
-type ConfigDir struct {
-	path   string
-	loader ConfigLoader
-}
-
-type configInfo struct {
-	Name string
-	Path string
-}
-
-// We might want to make that configurable, the idea of having a known suffix is to allow
-// other programs to write files in the config dir without being picked up by the facility.
-// There might be better ways of doing that.
-const configExt = ".conf"
-
-// File containing the pointer to current config
-const currentName = ".current"
-
-func configName(path string) string {
-	return filepath.Base(strings.TrimSuffix(path, configExt))
-}
-
-func NewConfigDir(path string, loader ConfigLoader) (*ConfigDir, error) {
-	stat, err := os.Stat(path)
-	if err != nil {
-		return nil, err
-	}
-	if !stat.Mode().IsDir() {
-		return nil, errors.New("not a directory")
+type (
+	// ConfigDir allows managing a multiple contextual configuration files. Each
+	// configuration is given a context name, e.g. `prod`, `staging`, `devel` and
+	// each stores a specific configuration.
+	ConfigDir struct {
+		path   string
+		loader ConfigLoader
 	}
 
-	return &ConfigDir{path, loader}, nil
-}
-
-func (c *ConfigDir) load(info *configInfo, as interface{}) error {
-	bytes, err := os.ReadFile(info.Path)
-	if err != nil {
-		return err
+	configInfo struct {
+		Name string
+		Path string
 	}
 
-	return c.loader.Unmarshal(bytes, as)
-}
-
-func (c *ConfigDir) dump(info *configInfo, from interface{}) error {
-	bytes, err := c.loader.Marshal(from)
-	if err != nil {
-		return err
+	ConfigDirOption interface {
+		apply(opt *ConfigDir) error
 	}
 
-	return os.WriteFile(info.Path, bytes, 0666)
-}
+	configDirOptionFn func(opt *ConfigDir) error
+)
 
-// At least one alphanum, "-" or "_"
-var allowedConfigNameChars = regexp.MustCompile("[a-zA-Z0-9-_]")
-
-func (c *ConfigDir) configInfo(name string, mustExist bool) (*configInfo, error) {
-	// Force at least two char to avoid "-" config names which can be dangerous to work with when
-	// interacting with shells
-	if len(name) < 2 {
-		return nil, errors.New("must be at least 2 char long")
-	}
-	if !allowedConfigNameChars.MatchString(name) {
-		return nil, errors.New("only alphanum and dash allowed")
-	}
-
-	path := filepath.Join(c.path, name) + configExt
-	if mustExist {
-		stat, err := os.Stat(path)
-		if err != nil {
+// NewConfigDir creates a ConfigDir at a given path.
+func NewConfigDir(path string, opts ...ConfigDirOption) (*ConfigDir, error) {
+	cfg := &ConfigDir{path: path, loader: JSONLoader}
+	for _, opt := range opts {
+		if err := opt.apply(cfg); err != nil {
 			return nil, err
 		}
-		if !stat.Mode().IsRegular() {
-			return nil, errors.New("not a regular file")
-		}
 	}
 
-	return &configInfo{Path: path, Name: name}, nil
+	stat, err := os.Stat(cfg.path)
+	if err != nil {
+		return nil, fmt.Errorf("ConfigDir's '%s' error: %w", cfg.path, err)
+	}
+
+	if !stat.Mode().IsDir() {
+		return nil, fmt.Errorf("ConfigDir's '%s' is not a directory", cfg.path)
+	}
+
+	return cfg, nil
 }
 
-func errConfigDir(name string, err error) error {
-	if err == nil {
+func (fn configDirOptionFn) apply(opt *ConfigDir) error {
+	return fn(opt)
+}
+
+func WithConfigDirLoader(loader ConfigLoader) ConfigDirOption {
+	return configDirOptionFn(func(opt *ConfigDir) error {
+		opt.loader = loader
 		return nil
-	}
-	return fmt.Errorf("configdir: %s: %w", name, err)
+	})
+}
+
+func WithXdgConfigPath(configPath string) ConfigDirOption {
+	return configDirOptionFn(func(opt *ConfigDir) error {
+		// xdg ensure that the parent directories are automatically created. Thus we
+		// ask for a dummy file with the correct parent path..
+		configPath, err := xdg.ConfigFile(path.Join(configPath, "dummy"))
+		if err != nil {
+			return fmt.Errorf("Failed creating configuration file path: %w", err)
+		}
+		// Remove the dummy part.
+		opt.path = path.Dir(configPath)
+		return nil
+	})
 }
 
 func (c *ConfigDir) Get(name string, as interface{}) error {
@@ -134,6 +102,7 @@ func (c *ConfigDir) Set(name string, from interface{}) error {
 	if err := c.dump(info, from); err != nil {
 		return errConfigDir(name, fmt.Errorf("dump: %w", err))
 	}
+
 	return nil
 }
 
@@ -201,4 +170,201 @@ func (c *ConfigDir) Current(as interface{}) (*configInfo, error) {
 	}
 
 	return info, nil
+}
+
+type (
+	ConfigDirFlag struct {
+		Config string `opt:""`
+	}
+
+	ConfigUseCmd struct {
+		Name string `arg:"" placeholder:"<name>"`
+	}
+
+	ConfigListCmd struct {
+	}
+
+	ConfigDirCmd struct {
+		Use  ConfigUseCmd  `cmd:"use"`
+		List ConfigListCmd `cmd:"list"`
+	}
+
+	ConfigDirCli struct {
+		ConfigDirFlag
+		Config ConfigDirCmd `cmd:"config"`
+
+		path      string
+		options   []ConfigDirOption
+		configDir *ConfigDir
+	}
+)
+
+func (c *ConfigDirCli) KongInit(path string, options ...ConfigDirOption) kong.Option {
+	c.path = path
+	c.options = options
+	return kong.Bind(c)
+}
+
+func (c *ConfigDirCli) Get(cfg interface{}) error {
+	configDir := c.configDir
+	target := c.ConfigDirFlag.Config
+
+	if target == "" {
+		_, err := configDir.Current(cfg)
+		if err != nil {
+			return err
+		}
+	}
+
+	return configDir.Get(target, cfg)
+}
+
+func (c *ConfigDirCli) Set(cfg interface{}, setCurrent bool) error {
+	target := c.ConfigDirFlag.Config
+	if target == "" {
+		target = "default"
+	}
+
+	if err := c.configDir.Set(target, cfg); err != nil {
+		return err
+	}
+
+	if setCurrent {
+		return c.configDir.Use(target)
+	}
+
+	return nil
+}
+
+func (c *ConfigDirCli) load() (err error) {
+	if c.configDir != nil {
+		return nil
+	}
+	c.configDir, err = NewConfigDir(c.path, c.options...)
+	return err
+}
+
+func (f *ConfigDirFlag) BeforeResolve(c *ConfigDirCli) (err error) {
+	return c.load()
+}
+
+func (f *ConfigDirFlag) Help() string {
+	return "Name of the configuration to load. See 'config' sub-command help for more information."
+}
+
+func (u *ConfigDirCmd) BeforeResolve(c *ConfigDirCli) (err error) {
+	return c.load()
+}
+
+func (u *ConfigDirCmd) Help() string {
+	return `The config sub-command family of commands allow managing parallel
+configurations. A configuration contains the information, usually URL and
+credentials, that allow connecting to a service. Configurations are referenced by
+a unique name, for example 'prod' or 'staging'.
+`
+}
+
+func (u *ConfigListCmd) BeforeResolve(c *ConfigDirCli) (err error) {
+	return c.load()
+}
+
+func (u *ConfigListCmd) Run(c *ConfigDirCli) error {
+	configs, err := c.configDir.List()
+	if err != nil {
+		return fmt.Errorf("Failed listing configs: %w", err)
+	}
+
+	for _, name := range configs {
+		fmt.Println(name)
+	}
+
+	return nil
+}
+
+func (u *ConfigUseCmd) BeforeResolve(c *ConfigDirCli) (err error) {
+	return c.load()
+}
+
+func (u *ConfigUseCmd) Run(c *ConfigDirCli) error {
+	return c.configDir.Use(u.Name)
+}
+
+// We might want to make that configurable, the idea of having a known suffix is to allow
+// other programs to write files in the config dir without being picked up by the facility.
+// There might be better ways of doing that.
+const configExt = ".conf"
+
+// File containing the pointer to current config
+const currentName = ".current"
+
+func configName(path string) string {
+	return filepath.Base(strings.TrimSuffix(path, configExt))
+}
+
+func (c *ConfigDir) load(info *configInfo, as interface{}) error {
+	bytes, err := os.ReadFile(info.Path)
+	if err != nil {
+		return err
+	}
+
+	return c.loader.Unmarshal(bytes, as)
+}
+
+func (c *ConfigDir) dump(info *configInfo, from interface{}) error {
+	bytes, err := c.loader.Marshal(from)
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(info.Path, bytes, 0666)
+}
+
+// Starts with an alphanum and at least 2 characters to avoid "-" config names
+// which can be dangerous to work with when interacting with shells.
+const allowedConfigNamePattern = "[a-zA-Z0-9][a-zA-Z0-9-_]+"
+
+var allowedConfigNameRegexp = regexp.MustCompile(allowedConfigNamePattern)
+
+func (c *ConfigDir) configInfo(name string, mustExist bool) (*configInfo, error) {
+	if !allowedConfigNameRegexp.MatchString(name) {
+		return nil, fmt.Errorf("Context name must match: %s", allowedConfigNamePattern)
+	}
+
+	path := filepath.Join(c.path, name) + configExt
+	if mustExist {
+		stat, err := os.Stat(path)
+		if err != nil {
+			return nil, err
+		}
+		if !stat.Mode().IsRegular() {
+			return nil, errors.New("not a regular file")
+		}
+	}
+
+	return &configInfo{Path: path, Name: name}, nil
+}
+
+func errConfigDir(name string, err error) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("configdir: %s: %w", name, err)
+}
+
+type ConfigLoader interface {
+	Unmarshal([]byte, interface{}) error
+	Marshal(interface{}) ([]byte, error)
+}
+
+// Simple implementation of a loader marshaling from/into a json structure
+type jsonLoader struct{}
+
+var JSONLoader = &jsonLoader{}
+
+func (l *jsonLoader) Unmarshal(b []byte, to interface{}) error {
+	return json.Unmarshal(b, to)
+}
+
+func (l *jsonLoader) Marshal(from interface{}) ([]byte, error) {
+	return json.Marshal(from)
 }

--- a/cli/configdir_test.go
+++ b/cli/configdir_test.go
@@ -1,0 +1,112 @@
+// Copyright © 2021 Optable Technologies Inc. All rights reserved.
+// See LICENSE for details.
+package cli
+
+import (
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func requireTempDir(t *testing.T) string {
+	dir, err := ioutil.TempDir("", "pkglib-test-*")
+	require.NoError(t, err)
+	return dir
+}
+
+func TestOpenConfigDirFailsOnFiles(t *testing.T) {
+	file, err := ioutil.TempFile("", "pkglib-test-*")
+	require.NoError(t, err)
+	defer os.Remove(file.Name())
+	configDir, err := NewConfigDir(file.Name(), &JSONMapLoader{})
+	assert.Nil(t, configDir)
+	assert.Error(t, err)
+}
+
+func TestOpenConfigDirDoesntFailOnDir(t *testing.T) {
+	dir := requireTempDir(t)
+	defer os.RemoveAll(dir)
+	configDir, err := NewConfigDir(dir, &JSONMapLoader{})
+	assert.NotNil(t, configDir)
+	assert.NoError(t, err)
+}
+
+func TestConfigDirCurrentFailsOnAbsentLink(t *testing.T) {
+	dir := requireTempDir(t)
+	defer os.RemoveAll(dir)
+
+	configDir, err := NewConfigDir(dir, &JSONMapLoader{})
+	require.NoError(t, err)
+
+	current, config, err := configDir.Current()
+	assert.Empty(t, current)
+	assert.Nil(t, config)
+	assert.Error(t, err)
+}
+
+func TestConfigDirOnlyListRecognizedFiles(t *testing.T) {
+	dir := requireTempDir(t)
+	defer os.RemoveAll(dir)
+	_, err := os.CreateTemp(dir, "nope-*.chose")
+	require.NoError(t, err)
+	_, err = os.CreateTemp(dir, "yes-*"+configExt)
+	require.NoError(t, err)
+
+	configDir, err := NewConfigDir(dir, &JSONMapLoader{})
+	require.NoError(t, err)
+	list, err := configDir.List()
+	require.NoError(t, err)
+	assert.Len(t, list, 1)
+	assert.True(t, strings.HasPrefix(list[0], "yes-"))
+}
+
+func TestConfigDirSetDumpsAndLoadConfig(t *testing.T) {
+	dir := requireTempDir(t)
+	defer os.RemoveAll(dir)
+
+	configDir, err := NewConfigDir(dir, &JSONMapLoader{})
+	require.NoError(t, err)
+
+	fortyTwoConfig := map[string]interface{}{
+		"name":  "forty two",
+		"count": 42,
+		"odd":   false,
+	}
+
+	twentyOne := map[string]interface{}{
+		"name":  "twenty one",
+		"count": 21,
+		"odd":   true,
+	}
+
+	err = configDir.Set("fortytwo", &fortyTwoConfig)
+	require.NoError(t, err)
+
+	err = configDir.Set("twentyone", &twentyOne)
+	require.NoError(t, err)
+
+	err = configDir.Use("twentyone")
+	require.NoError(t, err)
+
+	// Recreating a config dir to show state is loaded from disk
+	configDir, err = NewConfigDir(dir, &JSONMapLoader{})
+	require.NoError(t, err)
+
+	configs, err := configDir.List()
+	require.NoError(t, err)
+
+	assert.Len(t, configs, 2)
+
+	current, config, err := configDir.Current()
+	require.NoError(t, err)
+	assert.Equal(t, current, "twentyone")
+
+	currentMap := config.(map[string]interface{})
+	assert.Equal(t, "twenty one", currentMap["name"])
+	assert.Equal(t, float64(21), currentMap["count"])
+	assert.Equal(t, true, currentMap["odd"])
+}

--- a/cli/profile.go
+++ b/cli/profile.go
@@ -26,14 +26,14 @@ type (
 	// stopProfiling := cli.Profiling.Start()
 	// defer stopProfiling()
 	// ```
-	Profiling struct {
+	ProfilingFlag struct {
 		Profiling string `opt:"" hidden:"true" default:""`
 	}
 )
 
 // Start starts the profiling operation. It returns a function that needs to be
 // called when the profiling should stop.
-func (p *Profiling) Start() func() {
+func (p *ProfilingFlag) Start() func() {
 	path := profile.ProfilePath(".")
 	switch p.Profiling {
 	case "cpu":

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,8 @@ module github.com/optable/optable-pkglib
 go 1.16
 
 require (
+	github.com/adrg/xdg v0.3.3
+	github.com/alecthomas/kong v0.2.18-0.20210621110843-8b2821cc246b
 	github.com/pkg/profile v1.6.0
 	github.com/rs/zerolog v1.23.0
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,13 @@
+github.com/adrg/xdg v0.3.3 h1:s/tV7MdqQnzB1nKY8aqHvAMD+uCiuEDzVB5HLRY849U=
+github.com/adrg/xdg v0.3.3/go.mod h1:61xAR2VZcggl2St4O9ohF5qCKe08+JDmE4VNzPFQvOQ=
+github.com/alecthomas/kong v0.2.18-0.20210621110843-8b2821cc246b h1:I99raFEWy7Ibml39C+KUEyTzM6+gjVKqWzfsuBaRJYE=
+github.com/alecthomas/kong v0.2.18-0.20210621110843-8b2821cc246b/go.mod h1:ka3VZ8GZNPXv9Ov+j4YNLkI8mTuhXyr/0ktSlqIydQQ=
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/profile v1.6.0 h1:hUDfIISABYI59DyeB3OTay/HxSRwTQ8rB/H83k6r5dM=
 github.com/pkg/profile v1.6.0/go.mod h1:qBsxPvzyUincmltOk6iyRVxHYg4adc0OFOv72ZdLa18=
@@ -37,5 +43,6 @@ golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
+gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
Allow managing various config files handled by the same config loader/dumper in a config directory.
This is typically used to store configs representing different contexts (example for authentication) as separate files.

The state of the config dir is directly reflecting the filesystem's one (no caching involved) and allows the following operations:

With `config` shape being defined by loader's implementation:
- Get(name) => config
- Set(name, config) => void
- List() => []string of config names
- Current() => name, config (the config pointed by a current symlink)
- Use(name) => persist the current config symlink